### PR TITLE
Improve code readability 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length = 300
+max-line-length = 88

--- a/crim.py
+++ b/crim.py
@@ -1,33 +1,112 @@
 import re
 
-re_date = "(?i)(?:[0-3]?\d(?:st|nd|rd|th)?\s+(?:of\s+)?(?:jan\.?|january|feb\.?|february|mar\.?|march|apr\.?|april|may|jun\.?|june|jul\.?|july|aug\.?|august|sep\.?|september|oct\.?|october|nov\.?|november|dec\.?|december)|(?:jan\.?|january|feb\.?|february|mar\.?|march|apr\.?|april|may|jun\.?|june|jul\.?|july|aug\.?|august|sep\.?|september|oct\.?|october|nov\.?|november|dec\.?|december)\s+[0-3]?\d(?:st|nd|rd|th)?)(?:\,)?\s*(?:\d{4})?|[0-3]?\d[-\./][0-3]?\d[-\./]\d{2,4}"
-re_time = '(?i)\d{1,2}:\d{2} ?(?:[ap]\.?m\.?)?|\d[ap]\.?m\.?'
-re_phone = '''((?:(?<![\d-])(?:\+?\d{1,3}[-.\s*]?)?(?:\(?\d{3}\)?[-.\s*]?)?\d{3}[-.\s*]?\d{4}(?![\d-]))|(?:(?<![\d-])(?:(?:\(\+?\d{2}\))|(?:\+?\d{2}))\s*\d{2}\s*\d{3}\s*\d{4}(?![\d-])))'''
-re_phones_with_exts = '(?i)(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:\(\s*(?:[2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|(?:[2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?(?:[2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?(?:[0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(?:\d+)?)'
-re_link = r'(?i)((?:https?://|www\d{0,3}[.])?[a-z0-9.\-]+[.](?:(?:international)|(?:construction)|(?:contractors)|(?:enterprises)|(?:photography)|(?:immobilien)|(?:management)|(?:technology)|(?:directory)|(?:education)|(?:equipment)|(?:institute)|(?:marketing)|(?:solutions)|(?:builders)|(?:clothing)|(?:computer)|(?:democrat)|(?:diamonds)|(?:graphics)|(?:holdings)|(?:lighting)|(?:plumbing)|(?:training)|(?:ventures)|(?:academy)|(?:careers)|(?:company)|(?:domains)|(?:florist)|(?:gallery)|(?:guitars)|(?:holiday)|(?:kitchen)|(?:recipes)|(?:shiksha)|(?:singles)|(?:support)|(?:systems)|(?:agency)|(?:berlin)|(?:camera)|(?:center)|(?:coffee)|(?:estate)|(?:kaufen)|(?:luxury)|(?:monash)|(?:museum)|(?:photos)|(?:repair)|(?:social)|(?:tattoo)|(?:travel)|(?:viajes)|(?:voyage)|(?:build)|(?:cheap)|(?:codes)|(?:dance)|(?:email)|(?:glass)|(?:house)|(?:ninja)|(?:photo)|(?:shoes)|(?:solar)|(?:today)|(?:aero)|(?:arpa)|(?:asia)|(?:bike)|(?:buzz)|(?:camp)|(?:club)|(?:coop)|(?:farm)|(?:gift)|(?:guru)|(?:info)|(?:jobs)|(?:kiwi)|(?:land)|(?:limo)|(?:link)|(?:menu)|(?:mobi)|(?:moda)|(?:name)|(?:pics)|(?:pink)|(?:post)|(?:rich)|(?:ruhr)|(?:sexy)|(?:tips)|(?:wang)|(?:wien)|(?:zone)|(?:biz)|(?:cab)|(?:cat)|(?:ceo)|(?:com)|(?:edu)|(?:gov)|(?:int)|(?:mil)|(?:net)|(?:onl)|(?:org)|(?:pro)|(?:red)|(?:tel)|(?:uno)|(?:xxx)|(?:ac)|(?:ad)|(?:ae)|(?:af)|(?:ag)|(?:ai)|(?:al)|(?:am)|(?:an)|(?:ao)|(?:aq)|(?:ar)|(?:as)|(?:at)|(?:au)|(?:aw)|(?:ax)|(?:az)|(?:ba)|(?:bb)|(?:bd)|(?:be)|(?:bf)|(?:bg)|(?:bh)|(?:bi)|(?:bj)|(?:bm)|(?:bn)|(?:bo)|(?:br)|(?:bs)|(?:bt)|(?:bv)|(?:bw)|(?:by)|(?:bz)|(?:ca)|(?:cc)|(?:cd)|(?:cf)|(?:cg)|(?:ch)|(?:ci)|(?:ck)|(?:cl)|(?:cm)|(?:cn)|(?:co)|(?:cr)|(?:cu)|(?:cv)|(?:cw)|(?:cx)|(?:cy)|(?:cz)|(?:de)|(?:dj)|(?:dk)|(?:dm)|(?:do)|(?:dz)|(?:ec)|(?:ee)|(?:eg)|(?:er)|(?:es)|(?:et)|(?:eu)|(?:fi)|(?:fj)|(?:fk)|(?:fm)|(?:fo)|(?:fr)|(?:ga)|(?:gb)|(?:gd)|(?:ge)|(?:gf)|(?:gg)|(?:gh)|(?:gi)|(?:gl)|(?:gm)|(?:gn)|(?:gp)|(?:gq)|(?:gr)|(?:gs)|(?:gt)|(?:gu)|(?:gw)|(?:gy)|(?:hk)|(?:hm)|(?:hn)|(?:hr)|(?:ht)|(?:hu)|(?:id)|(?:ie)|(?:il)|(?:im)|(?:in)|(?:io)|(?:iq)|(?:ir)|(?:is)|(?:it)|(?:je)|(?:jm)|(?:jo)|(?:jp)|(?:ke)|(?:kg)|(?:kh)|(?:ki)|(?:km)|(?:kn)|(?:kp)|(?:kr)|(?:kw)|(?:ky)|(?:kz)|(?:la)|(?:lb)|(?:lc)|(?:li)|(?:lk)|(?:lr)|(?:ls)|(?:lt)|(?:lu)|(?:lv)|(?:ly)|(?:ma)|(?:mc)|(?:md)|(?:me)|(?:mg)|(?:mh)|(?:mk)|(?:ml)|(?:mm)|(?:mn)|(?:mo)|(?:mp)|(?:mq)|(?:mr)|(?:ms)|(?:mt)|(?:mu)|(?:mv)|(?:mw)|(?:mx)|(?:my)|(?:mz)|(?:na)|(?:nc)|(?:ne)|(?:nf)|(?:ng)|(?:ni)|(?:nl)|(?:no)|(?:np)|(?:nr)|(?:nu)|(?:nz)|(?:om)|(?:pa)|(?:pe)|(?:pf)|(?:pg)|(?:ph)|(?:pk)|(?:pl)|(?:pm)|(?:pn)|(?:pr)|(?:ps)|(?:pt)|(?:pw)|(?:py)|(?:qa)|(?:re)|(?:ro)|(?:rs)|(?:ru)|(?:rw)|(?:sa)|(?:sb)|(?:sc)|(?:sd)|(?:se)|(?:sg)|(?:sh)|(?:si)|(?:sj)|(?:sk)|(?:sl)|(?:sm)|(?:sn)|(?:so)|(?:sr)|(?:st)|(?:su)|(?:sv)|(?:sx)|(?:sy)|(?:sz)|(?:tc)|(?:td)|(?:tf)|(?:tg)|(?:th)|(?:tj)|(?:tk)|(?:tl)|(?:tm)|(?:tn)|(?:to)|(?:tp)|(?:tr)|(?:tt)|(?:tv)|(?:tw)|(?:tz)|(?:ua)|(?:ug)|(?:uk)|(?:us)|(?:uy)|(?:uz)|(?:va)|(?:vc)|(?:ve)|(?:vg)|(?:vi)|(?:vn)|(?:vu)|(?:wf)|(?:ws)|(?:ye)|(?:yt)|(?:za)|(?:zm)|(?:zw))(?:/[^\s()<>]+[^\s`!()\[\]{};:\'".,<>?\xab\xbb\u201c\u201d\u2018\u2019])?)'
-re_email = r"(?i)([A-Za-z0-9!#$%&'*+\/=?^_{|.}~-]+@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)"
-re_ipv4 = '(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)'
-re_ipv6 = '\s*(?!.*::.*::)(?:(?!:)|:(?=:))(?:[0-9a-f]{0,4}(?:(?<=::)|(?<!::):)){6}(?:[0-9a-f]{0,4}(?:(?<=::)|(?<!::):)[0-9a-f]{0,4}(?:(?<=::)|(?<!:)|(?<=:)(?<!::):)|(?:25[0-4]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-4]|2[0-4]\d|1\d\d|[1-9]?\d)){3})\s*'
-re_ip_pattern = re_ipv4 + '|' + re_ipv6
-re_not_known_ports   = '6[0-5]{2}[0-3][0-5]|[1-5][\d]{4}|[2-9][\d]{3}|1[1-9][\d]{2}|10[3-9][\d]|102[4-9]'
-re_price = '[$]\s?[+-]?[0-9]{1,3}(?:(?:,?[0-9]{3}))*(?:\.[0-9]{1,2})?'
-re_hex_color = '(#(?:[0-9a-fA-F]{8})|#(?:[0-9a-fA-F]{3}){1,2})\\b'
-re_credit_card = '((?:(?:\\d{4}[- ]?){3}\\d{4}|\\d{15,16}))(?![\\d])'
+re_date = (
+    r"(?i)(?:[0-3]?\d(?:st|nd|rd|th)?\s+(?:of\s+)?(?:jan\.?|january|feb\.?|february|"
+    r"mar\.?|march|apr\.?|april|may|jun\.?|june|jul\.?|july|aug\.?|august|sep\.?|"
+    r"september|oct\.?|october|nov\.?|november|dec\.?|december)|(?:jan\.?|january|"
+    r"feb\.?|february|mar\.?|march|apr\.?|april|may|jun\.?|june|jul\.?|july|aug\.?|"
+    r"august|sep\.?|september|oct\.?|october|nov\.?|november|dec\.?|december)\s+[0-3]?"
+    r"\d(?:st|nd|rd|th)?)(?:\,)?\s*(?:\d{4})?|[0-3]?\d[-\./][0-3]?\d[-\./]\d{2,4}"
+)
+re_time = r"(?i)\d{1,2}:\d{2} ?(?:[ap]\.?m\.?)?|\d[ap]\.?m\.?"
+re_phone = (
+    r"((?:(?<![\d-])(?:\+?\d{1,3}[-.\s*]?)?(?:\(?\d{3}\)?[-.\s*]?)?\d{3}[-.\s*]?"
+    r"\d{4}(?![\d-]))|(?:(?<![\d-])(?:(?:\(\+?\d{2}\))|(?:\+?\d{2}))\s*\d{2}\s*"
+    r"\d{3}\s*\d{4}(?![\d-])))"
+)
+re_phones_with_exts = (
+    r"(?i)(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:\(\s*(?:[2-9]1[02-9]|[2-9][02-8]1|"
+    r"[2-9][02-8][02-9])\s*\)|(?:[2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))"
+    r"\s*(?:[.-]\s*)?)?(?:[2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})"
+    r"\s*(?:[.-]\s*)?(?:[0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(?:\d+)?)"
+)
+re_link = (
+    r"(?i)((?:https?://|www\d{0,3}[.])?[a-z0-9.\-]+[.](?:(?:international)|"
+    r"(?:construction)|(?:contractors)|(?:enterprises)|(?:photography)|(?:immobilien)|"
+    r"(?:management)|(?:technology)|(?:directory)|(?:education)|(?:equipment)|"
+    r"(?:institute)|(?:marketing)|(?:solutions)|(?:builders)|(?:clothing)|"
+    r"(?:computer)|(?:democrat)|(?:diamonds)|(?:graphics)|(?:holdings)|(?:lighting)|"
+    r"(?:plumbing)|(?:training)|(?:ventures)|(?:academy)|(?:careers)|(?:company)|"
+    r"(?:domains)|(?:florist)|(?:gallery)|(?:guitars)|(?:holiday)|(?:kitchen)|"
+    r"(?:recipes)|(?:shiksha)|(?:singles)|(?:support)|(?:systems)|(?:agency)|"
+    r"(?:berlin)|(?:camera)|(?:center)|(?:coffee)|(?:estate)|(?:kaufen)|(?:luxury)|"
+    r"(?:monash)|(?:museum)|(?:photos)|(?:repair)|(?:social)|(?:tattoo)|(?:travel)|"
+    r"(?:viajes)|(?:voyage)|(?:build)|(?:cheap)|(?:codes)|(?:dance)|(?:email)|"
+    r"(?:glass)|(?:house)|(?:ninja)|(?:photo)|(?:shoes)|(?:solar)|(?:today)|(?:aero)|"
+    r"(?:arpa)|(?:asia)|(?:bike)|(?:buzz)|(?:camp)|(?:club)|(?:coop)|(?:farm)|(?:gift)|"
+    r"(?:guru)|(?:info)|(?:jobs)|(?:kiwi)|(?:land)|(?:limo)|(?:link)|(?:menu)|(?:mobi)|"
+    r"(?:moda)|(?:name)|(?:pics)|(?:pink)|(?:post)|(?:rich)|(?:ruhr)|(?:sexy)|(?:tips)|"
+    r"(?:wang)|(?:wien)|(?:zone)|(?:biz)|(?:cab)|(?:cat)|(?:ceo)|(?:com)|"
+    r"(?:edu)|(?:gov)|(?:int)|(?:mil)|(?:net)|(?:onl)|(?:org)|(?:pro)|(?:red)|(?:tel)|"
+    r"(?:uno)|(?:xxx)|(?:ac)|(?:ad)|(?:ae)|(?:af)|(?:ag)|(?:ai)|(?:al)|(?:am)|(?:an)|"
+    r"(?:ao)|(?:aq)|(?:ar)|(?:as)|(?:at)|(?:au)|(?:aw)|(?:ax)|(?:az)|(?:ba)|(?:bb)|"
+    r"(?:bd)|(?:be)|(?:bf)|(?:bg)|(?:bh)|(?:bi)|(?:bj)|(?:bm)|(?:bn)|(?:bo)|(?:br)|"
+    r"(?:bs)|(?:bt)|(?:bv)|(?:bw)|(?:by)|(?:bz)|(?:ca)|(?:cc)|(?:cd)|(?:cf)|(?:cg)|"
+    r"(?:ch)|(?:ci)|(?:ck)|(?:cl)|(?:cm)|(?:cn)|(?:co)|(?:cr)|(?:cu)|(?:cv)|(?:cw)|"
+    r"(?:cx)|(?:cy)|(?:cz)|(?:de)|(?:dj)|(?:dk)|(?:dm)|(?:do)|(?:dz)|(?:ec)|(?:ee)|"
+    r"(?:eg)|(?:er)|(?:es)|(?:et)|(?:eu)|(?:fi)|(?:fj)|(?:fk)|(?:fm)|(?:fo)|(?:fr)|"
+    r"(?:ga)|(?:gb)|(?:gd)|(?:ge)|(?:gf)|(?:gg)|(?:gh)|(?:gi)|(?:gl)|(?:gm)|(?:gn)|"
+    r"(?:gp)|(?:gq)|(?:gr)|(?:gs)|(?:gt)|(?:gu)|(?:gw)|(?:gy)|(?:hk)|(?:hm)|(?:hn)|"
+    r"(?:hr)|(?:ht)|(?:hu)|(?:id)|(?:ie)|(?:il)|(?:im)|(?:in)|(?:io)|(?:iq)|(?:ir)|"
+    r"(?:is)|(?:it)|(?:je)|(?:jm)|(?:jo)|(?:jp)|(?:ke)|(?:kg)|(?:kh)|(?:ki)|(?:km)|"
+    r"(?:kn)|(?:kp)|(?:kr)|(?:kw)|(?:ky)|(?:kz)|(?:la)|(?:lb)|(?:lc)|(?:li)|(?:lk)|"
+    r"(?:lr)|(?:ls)|(?:lt)|(?:lu)|(?:lv)|(?:ly)|(?:ma)|(?:mc)|(?:md)|(?:me)|(?:mg)|"
+    r"(?:mh)|(?:mk)|(?:ml)|(?:mm)|(?:mn)|(?:mo)|(?:mp)|(?:mq)|(?:mr)|(?:ms)|(?:mt)|"
+    r"(?:mu)|(?:mv)|(?:mw)|(?:mx)|(?:my)|(?:mz)|(?:na)|(?:nc)|(?:ne)|(?:nf)|(?:ng)|"
+    r"(?:ni)|(?:nl)|(?:no)|(?:np)|(?:nr)|(?:nu)|(?:nz)|(?:om)|(?:pa)|(?:pe)|(?:pf)|"
+    r"(?:pg)|(?:ph)|(?:pk)|(?:pl)|(?:pm)|(?:pn)|(?:pr)|(?:ps)|(?:pt)|(?:pw)|(?:py)|"
+    r"(?:qa)|(?:re)|(?:ro)|(?:rs)|(?:ru)|(?:rw)|(?:sa)|(?:sb)|(?:sc)|(?:sd)|(?:se)|"
+    r"(?:sg)|(?:sh)|(?:si)|(?:sj)|(?:sk)|(?:sl)|(?:sm)|(?:sn)|(?:so)|(?:sr)|(?:st)|"
+    r"(?:su)|(?:sv)|(?:sx)|(?:sy)|(?:sz)|(?:tc)|(?:td)|(?:tf)|(?:tg)|(?:th)|(?:tj)|"
+    r"(?:tk)|(?:tl)|(?:tm)|(?:tn)|(?:to)|(?:tp)|(?:tr)|(?:tt)|(?:tv)|(?:tw)|(?:tz)|"
+    r"(?:ua)|(?:ug)|(?:uk)|(?:us)|(?:uy)|(?:uz)|(?:va)|(?:vc)|(?:ve)|(?:vg)|(?:vi)|"
+    r"(?:vn)|(?:vu)|(?:wf)|(?:ws)|(?:ye)|(?:yt)|(?:za)|(?:zm)|(?:zw))"
+    r"(?:/[^\s()<>]+[^\s`!()\[\]{};:'\".,<>?\xab\xbb\u201c\u201d\u2018\u2019])?)"
+)
+re_email = (
+    r"(?i)([A-Za-z0-9!#$%&'*+\/=?^_{|.}~-]+@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+"
+    r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)"
+)
+re_ipv4 = (
+    r"(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]"
+    r"[0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|"
+    r"[01]?[0-9][0-9]?)"
+)
+re_ipv6 = (
+    r"\s*(?!.*::.*::)(?:(?!:)|:(?=:))(?:[0-9a-f]{0,4}(?:(?<=::)|(?<!::):)){6}"
+    r"(?:[0-9a-f]{0,4}(?:(?<=::)|(?<!::):)[0-9a-f]{0,4}(?:(?<=::)|(?<!:)|(?<=:)"
+    r"(?<!::):)|(?:25[0-4]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-4]|2[0-4]\d|1\d\d|"
+    r"[1-9]?\d)){3})\s*"
+)
+re_ip_pattern = re_ipv4 + "|" + re_ipv6
+re_not_known_ports = (
+    r"6[0-5]{2}[0-3][0-5]|[1-5][\d]{4}|[2-9][\d]{3}|1[1-9][\d]{2}|10[3-9][\d]|102[4-9]"
+)
+re_price = r"[$]\s?[+-]?[0-9]{1,3}(?:(?:,?[0-9]{3}))*(?:\.[0-9]{1,2})?"
+re_hex_color = "(#(?:[0-9a-fA-F]{8})|#(?:[0-9a-fA-F]{3}){1,2})\\b"
+re_credit_card = "((?:(?:\\d{4}[- ]?){3}\\d{4}|\\d{15,16}))(?![\\d])"
 re_visa_card = r"4\d{3}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}"
 re_master_card = r"5[1-5]\d{2}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}"
-re_btc_address = '(?<![a-km-zA-HJ-NP-Z0-9])[13][a-km-zA-HJ-NP-Z0-9]{26,33}(?![a-km-zA-HJ-NP-Z0-9])'
-re_street_address = '\d{1,4} [\w\s]{1,20}(?:street|st|avenue|ave|road|rd|highway|hwy|square|sq|trail|trl|drive|dr|court|ct|park|parkway|pkwy|circle|cir|boulevard|blvd)\W?(?=\s|$)'
-re_zip_code = r'\b\d{5}(?:[-\s]\d{4})?\b'
-re_po_box = r'(?i)P\.? ?O\.? Box \d+'
-re_ssn = '(?:\d{3}-\d{2}-\d{4})'
-re_md5_hashes = '[0-9a-fA-F]{32}'
-re_sha1_hashes = '[0-9a-fA-F]{40}'
-re_sha256_hashes = '[0-9a-fA-F]{64}'
-re_isbn13 = '(?:[\d]-?){12}[\dxX]'
-re_isbn10 = '(?:[\d]-?){9}[\dxX]'
-re_mac_address = '(([0-9a-fA-F]{2}[:-]){5}([0-9a-fA-F]{2}))'
-re_iban_number = '[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}([A-Z\d]?){0,16}'
-re_git_repo = """((git|ssh|http(s)?)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:/\-~]+)(\.git)(\/)?"""
+re_btc_address = (
+    "(?<![a-km-zA-HJ-NP-Z0-9])[13][a-km-zA-HJ-NP-Z0-9]{26,33}(?![a-km-zA-HJ-NP-Z0-9])"
+)
+re_street_address = (
+    r"\d{1,4} [\w\s]{1,20}(?:street|st|avenue|ave|road|rd|highway|hwy|square|sq|trail|"
+    r"trl|drive|dr|court|ct|park|parkway|pkwy|circle|cir|boulevard|blvd)\W?(?=\s|$)"
+)
+re_zip_code = r"\b\d{5}(?:[-\s]\d{4})?\b"
+re_po_box = r"(?i)P\.? ?O\.? Box \d+"
+re_ssn = r"(?:\d{3}-\d{2}-\d{4})"
+re_md5_hashes = r"[0-9a-fA-F]{32}"
+re_sha1_hashes = r"[0-9a-fA-F]{40}"
+re_sha256_hashes = r"[0-9a-fA-F]{64}"
+re_isbn13 = r"(?:[\d]-?){12}[\dxX]"
+re_isbn10 = r"(?:[\d]-?){9}[\dxX]"
+re_mac_address = r"(([0-9a-fA-F]{2}[:-]){5}([0-9a-fA-F]{2}))"
+re_iban_number = r"[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}([A-Z\d]?){0,16}"
+re_git_repo = (
+    r"((git|ssh|http(s)?)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:/\-~]+)(\.git)(\/)?"
+)
 
 
 regex_map = {
@@ -58,10 +137,10 @@ regex_map = {
     "isbn10": re_isbn10,
     "mac_addresses": re_mac_address,
     "iban_numbers": re_iban_number,
-    "git_repos": re_git_repo
+    "git_repos": re_git_repo,
 }
 
-    
+
 def match(text: str, regex: str) -> list:
     """Function to match using regex findall function
     Args:
@@ -73,6 +152,7 @@ def match(text: str, regex: str) -> list:
     parsed = list(re.findall(regex, text))
     return parsed
 
+
 def match_by_regex_search(text: str, regex: str) -> list:
     """Function to match using regex search function
     Args:
@@ -81,7 +161,7 @@ def match_by_regex_search(text: str, regex: str) -> list:
     Returns:
         list (list): list of sensitive data found in lines
     """
-    parsed=[]
+    parsed = []
     for line in text.split():
         if re.search(regex, line):
             pattern_string = re.search(regex, line)
@@ -89,86 +169,114 @@ def match_by_regex_search(text: str, regex: str) -> list:
             parsed.append(sensitive_string)
     return parsed
 
+
 def dates(text: str) -> list:
     return match(text, regex_map["dates"])
+
 
 def times(text: str) -> list:
     return match(text, regex_map["times"])
 
+
 def phones(text: str) -> list:
     return match(text, regex_map["phones"])
+
 
 def phones_with_exts(text: str) -> list:
     return match(text, regex_map["phones_with_exts"])
 
-def emails(text:str) -> list:
+
+def emails(text: str) -> list:
     return match(text, regex_map["emails"])
+
 
 def links(text: str) -> list:
     return match_by_regex_search(text, regex_map["links"])
 
+
 def ipv4s(text: str) -> list:
     return match(text, regex_map["ipv4"])
+
 
 def ipv6s(text: str) -> list:
     return match(text, regex_map["ipv6"])
 
+
 def ips(text: str) -> list:
     return match(text, regex_map["ips"])
+
 
 def not_known_ports(text: str) -> list:
     return match(text, regex_map["not_known_ports"])
 
+
 def prices(text: str) -> list:
     return match(text, regex_map["prices"])
+
 
 def hex_colors(text: str) -> list:
     return match(text, regex_map["hex_colors"])
 
+
 def credit_cards(text: str) -> list:
     return match(text, regex_map["credit_cards"])
+
 
 def visa_cards(text: str) -> list:
     return match(text, regex_map["visa_cards"])
 
+
 def master_cards(text: str) -> list:
     return match(text, regex_map["master_cards"])
+
 
 def btc_address(text: str) -> list:
     return match(text, regex_map["btc_addresses"])
 
+
 def street_addresses(text: str) -> list:
     return match(text, regex_map["street_addresses"])
+
 
 def zip_codes(text: str) -> list:
     return match(text, regex_map["zip_codes"])
 
+
 def po_boxes(text: str) -> list:
     return match(text, regex_map["po_boxes"])
+
 
 def ssn_numbers(text: str) -> list:
     return match(text, regex_map["ssn_number"])
 
+
 def md5_hashes(text: str) -> list:
     return match(text, regex_map["md5_hashes"])
+
 
 def sha1_hashes(text: str) -> list:
     return match(text, regex_map["sha1_hashes"])
 
+
 def sha256_hashes(text: str) -> list:
     return match(text, regex_map["sha256_hashes"])
+
 
 def isbn13s(text: str) -> list:
     return match(text, regex_map["isbn13"])
 
+
 def isbn10s(text: str) -> list:
     return match(text, regex_map["isbn10"])
+
 
 def mac_addresses(text: str) -> list:
     return match_by_regex_search(text, regex_map["mac_addresses"])
 
+
 def iban_numbers(text: str) -> list:
     return match(text, regex_map["iban_numbers"])
+
 
 def git_repos(text: str) -> list:
     return match_by_regex_search(text, regex_map["git_repos"])

--- a/test_crim.py
+++ b/test_crim.py
@@ -1,59 +1,81 @@
 import crim as cregex
 
+
 def test_cregex_dates():
-    test_data = ["3-23-17",
-		"3.23.17",
-		"03.23.17",
-		"March 23th, 2017",
-		"Mar 23th 2017",
-		"Mar. 23th, 2017",
-		"23 Mar 2017",]
+    test_data = [
+        "3-23-17",
+        "3.23.17",
+        "03.23.17",
+        "March 23th, 2017",
+        "Mar 23th 2017",
+        "Mar. 23th, 2017",
+        "23 Mar 2017",
+    ]
 
     for test_string in test_data:
-        assert cregex.dates(test_string) == [test_string], "Dates regex failed on: " + test_string
+        assert cregex.dates(test_string) == [test_string], (
+            "Dates regex failed on: " + test_string
+        )
+
 
 def test_cregex_times():
-    test_data = ["09:45",
-		"9:45",
-		"23:45",
-		"9:00am",
-		"9am",
-		"9:00 A.M.",
-		"9:00 pm",]
+    test_data = [
+        "09:45",
+        "9:45",
+        "23:45",
+        "9:00am",
+        "9am",
+        "9:00 A.M.",
+        "9:00 pm",
+    ]
 
     for test_string in test_data:
-        assert cregex.times(test_string) == [test_string], "Times regex failed on: " + test_string
+        assert cregex.times(test_string) == [test_string], (
+            "Times regex failed on: " + test_string
+        )
+
 
 def test_cregex_phones():
-    test_data = ["12345678900",
-		"1234567890",
-		"+1 234 567 8900",
-		"234-567-8900",
-		"1-234-567-8900",
-		"1.234.567.8900",
-		"5678900",
-		"567-8900",
-		"(003) 555-1212",
-		"+41 22 730 5989",
-		"+442345678900"]
+    test_data = [
+        "12345678900",
+        "1234567890",
+        "+1 234 567 8900",
+        "234-567-8900",
+        "1-234-567-8900",
+        "1.234.567.8900",
+        "5678900",
+        "567-8900",
+        "(003) 555-1212",
+        "+41 22 730 5989",
+        "+442345678900",
+    ]
 
     for test_string in test_data:
-        assert cregex.phones(test_string) == [test_string], "Phones regex failed on: " + test_string
+        assert cregex.phones(test_string) == [test_string], (
+            "Phones regex failed on: " + test_string
+        )
+
 
 def test_cregex_phones_with_exts():
-    test_data = ["(523)222-8888 ext 527",
-		"(523)222-8888x623",
-		"(523)222-8888 x623",
-		"(523)222-8888 x 623",
-		"(523)222-8888EXT623",
-		"523-222-8888EXT623",
-		"(523) 222-8888 x 623",]
+    test_data = [
+        "(523)222-8888 ext 527",
+        "(523)222-8888x623",
+        "(523)222-8888 x623",
+        "(523)222-8888 x 623",
+        "(523)222-8888EXT623",
+        "523-222-8888EXT623",
+        "(523) 222-8888 x 623",
+    ]
 
     for test_string in test_data:
-        assert cregex.phones_with_exts(test_string) == [test_string], "Phones with exts regex failed on: " + test_string
+        assert cregex.phones_with_exts(test_string) == [test_string], (
+            "Phones with exts regex failed on: " + test_string
+        )
+
 
 def test_cregex_links():
-    test_data = ["http://www.google.com",
+    test_data = [
+        "http://www.google.com",
         "https://www.google.com",
         "www.google.com",
         "http://www.google.com/search?q=python",
@@ -73,103 +95,128 @@ def test_cregex_links():
         "www.google.com/search?q=python&hl=en&tbm=nws&tbs=qdr:d&tbs=qdr:w",
         "http://www.google.com/search?q=python&hl=en&t",
         "www.google.com",
-		"http://www.google.com",
-		"www.google.com/?query=dog",
-		"sub.example.com",
-		"http://www.google.com/%&#/?q=dog",
-		"google.com",]
-    
+        "http://www.google.com",
+        "www.google.com/?query=dog",
+        "sub.example.com",
+        "http://www.google.com/%&#/?q=dog",
+        "google.com",
+    ]
+
     for test_string in test_data:
-        assert cregex.links(test_string) == [test_string], "Links regex failed on: " + test_string
+        assert cregex.links(test_string) == [test_string], (
+            "Links regex failed on: " + test_string
+        )
+
 
 def test_cregex_emails():
-    test_data = ["john.smith@gmail.com",
-		"john_smith@gmail.com",
-		"john@example.net",
-		"John@example.net",
-        "jane@example.gov.us"]
+    test_data = [
+        "john.smith@gmail.com",
+        "john_smith@gmail.com",
+        "john@example.net",
+        "John@example.net",
+        "jane@example.gov.us",
+    ]
 
     failing_tests = ["john.smith@gmail..com"]
 
     for test_string in test_data:
-        assert cregex.emails(test_string) == [test_string], "Emails regex failed on: " + test_string
+        assert cregex.emails(test_string) == [test_string], (
+            "Emails regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.emails(test_string) != [test_string], "These should not be matched " + test_string
+        assert cregex.emails(test_string) != [test_string], (
+            "These should not be matched " + test_string
+        )
+
 
 def test_cregex_ipv4s():
-    test_data = ["127.0.0.1",
-		"192.168.1.1",
-		"8.8.8.8",
-		"192.30.253.113",
-		"216.58.194.46"]
-    
+    test_data = [
+        "127.0.0.1",
+        "192.168.1.1",
+        "8.8.8.8",
+        "192.30.253.113",
+        "216.58.194.46",
+    ]
+
     for test_string in test_data:
-        assert cregex.ipv4s(test_string) == [test_string], "IPv4s regex failed on: " + test_string
+        assert cregex.ipv4s(test_string) == [test_string], (
+            "IPv4s regex failed on: " + test_string
+        )
+
 
 def test_cregex_ipv6s():
-    test_data = ["fe80:0000:0000:0000:0204:61ff:fe9d:f156",
-		"fe80:0:0:0:204:61ff:fe9d:f156",
-		"fe80::204:61ff:fe9d:f156",
-		"fe80:0000:0000:0000:0204:61ff:254.157.241.86",
-		"fe80:0:0:0:0204:61ff:254.157.241.86",
-		"::1"]
+    test_data = [
+        "fe80:0000:0000:0000:0204:61ff:fe9d:f156",
+        "fe80:0:0:0:204:61ff:fe9d:f156",
+        "fe80::204:61ff:fe9d:f156",
+        "fe80:0000:0000:0000:0204:61ff:254.157.241.86",
+        "fe80:0:0:0:0204:61ff:254.157.241.86",
+        "::1",
+    ]
 
     for test_string in test_data:
-        assert cregex.ipv6s(test_string) == [test_string], "IPv6s regex failed on: " + test_string
+        assert cregex.ipv6s(test_string) == [test_string], (
+            "IPv6s regex failed on: " + test_string
+        )
+
 
 def test_cregex_ips():
-    test_data = ["127.0.0.1",
-		"192.168.1.1",
-		"8.8.8.8",
-		"192.30.253.113",
-		"216.58.194.46",
-		"fe80:0000:0000:0000:0204:61ff:fe9d:f156",
-		"fe80:0:0:0:204:61ff:fe9d:f156",
-		"fe80::204:61ff:fe9d:f156",
-		"fe80:0000:0000:0000:0204:61ff:254.157.241.86",
-		"fe80:0:0:0:0204:61ff:254.157.241.86",
-		"::1"]
+    test_data = [
+        "127.0.0.1",
+        "192.168.1.1",
+        "8.8.8.8",
+        "192.30.253.113",
+        "216.58.194.46",
+        "fe80:0000:0000:0000:0204:61ff:fe9d:f156",
+        "fe80:0:0:0:204:61ff:fe9d:f156",
+        "fe80::204:61ff:fe9d:f156",
+        "fe80:0000:0000:0000:0204:61ff:254.157.241.86",
+        "fe80:0:0:0:0204:61ff:254.157.241.86",
+        "::1",
+    ]
 
     for test_string in test_data:
-        assert cregex.ips(test_string) == [test_string], "IPs regex failed on: " + test_string
+        assert cregex.ips(test_string) == [test_string], (
+            "IPs regex failed on: " + test_string
+        )
+
 
 def test_cregex_not_ports():
-    test_data = ["1024",
-		"2121",
-		"8080",
-		"12345",
-		"55555",
-		"65535"]
+    test_data = ["1024", "2121", "8080", "12345", "55555", "65535"]
 
-    failing_tests = ["21",
-		"80",
-		"1023",
-		"65536"]
+    failing_tests = ["21", "80", "1023", "65536"]
 
     for test_string in test_data:
-        assert cregex.not_known_ports(test_string) == [test_string], "Not ports regex failed on: " + test_string
+        assert cregex.not_known_ports(test_string) == [test_string], (
+            "Not ports regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.not_known_ports(test_string) != [test_string], "This is a well known port " + test_string
+        assert cregex.not_known_ports(test_string) != [test_string], (
+            "This is a well known port " + test_string
+        )
+
 
 def test_cregex_prices():
-    test_data = ["$1.23",
-		"$1",
-		"$1,000",
-		"$10,000.00"]
+    test_data = ["$1.23", "$1", "$1,000", "$10,000.00"]
 
-    failing_tests = ["$1,10,0",
-		"$100.000"]
+    failing_tests = ["$1,10,0", "$100.000"]
 
     for test_string in test_data:
-        assert cregex.prices(test_string) == [test_string], "Prices regex failed on: " + test_string
+        assert cregex.prices(test_string) == [test_string], (
+            "Prices regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.prices(test_string) != [test_string], "This is not a price " + test_string
+        assert cregex.prices(test_string) != [test_string], (
+            "This is not a price " + test_string
+        )
+
 
 def test_cregex_hex_colors():
-    test_data = ["#000000",
+    test_data = [
+        "#000000",
         "#FFFFFF",
         "#FF0000",
         "#00FF00",
@@ -178,244 +225,328 @@ def test_cregex_hex_colors():
         "#FF00FF",
         "#00FFFF",
         "#000000FF",
-        "#FFFFFFFF"]
+        "#FFFFFFFF",
+    ]
 
-    failing_tests = ["#000000FFF",
-        "#FFFFFFFFF"]
+    failing_tests = ["#000000FFF", "#FFFFFFFFF"]
 
     for test_string in test_data:
-        assert cregex.hex_colors(test_string) == [test_string], "Hex colors regex failed on: " + test_string
+        assert cregex.hex_colors(test_string) == [test_string], (
+            "Hex colors regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.hex_colors(test_string) != [test_string], "This is not a hex color " + test_string
+        assert cregex.hex_colors(test_string) != [test_string], (
+            "This is not a hex color " + test_string
+        )
+
 
 def test_cregex_credit_cards():
-    test_data = ["0000-0000-0000-0000",
-		"0123456789012345",
-		"0000 0000 0000 0000",
-		"012345678901234"]
+    test_data = [
+        "0000-0000-0000-0000",
+        "0123456789012345",
+        "0000 0000 0000 0000",
+        "012345678901234",
+    ]
 
     for test_string in test_data:
-        assert cregex.credit_cards(test_string) == [test_string], "Credit cards regex failed on: " + test_string
+        assert cregex.credit_cards(test_string) == [test_string], (
+            "Credit cards regex failed on: " + test_string
+        )
+
 
 def test_cregex_visa_cards():
-    test_data=["4111 1111 1111 1111",
-		"4222 2222 2222 2222"]
+    test_data = ["4111 1111 1111 1111", "4222 2222 2222 2222"]
 
-    failing_tests = ["5500 0000 0000 0004",
-		"3400 0000 0000 009",
-		"3000 0000 0000 04"]
+    failing_tests = ["5500 0000 0000 0004", "3400 0000 0000 009", "3000 0000 0000 04"]
 
     for test_string in test_data:
-        assert cregex.visa_cards(test_string) == [test_string], "Visa cards regex failed on: " + test_string
+        assert cregex.visa_cards(test_string) == [test_string], (
+            "Visa cards regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.visa_cards(test_string) != [test_string], "This is not a visa card " + test_string
+        assert cregex.visa_cards(test_string) != [test_string], (
+            "This is not a visa card " + test_string
+        )
 
 
 def test_cregex_master_cards():
-    test_data=["5500 0000 0000 0004",
-		"5500 3334 0000 1234"]
+    test_data = ["5500 0000 0000 0004", "5500 3334 0000 1234"]
 
-    failing_tests = ["4111 1111 1111 1111",
-		"4222 2222 2222 2222",
-		"3400 0000 0000 009",
-		"3000 0000 0000 04"]
+    failing_tests = [
+        "4111 1111 1111 1111",
+        "4222 2222 2222 2222",
+        "3400 0000 0000 009",
+        "3000 0000 0000 04",
+    ]
 
     for test_string in test_data:
-        assert cregex.master_cards(test_string) == [test_string], "Master cards regex failed on: " + test_string
+        assert cregex.master_cards(test_string) == [test_string], (
+            "Master cards regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.master_cards(test_string) != [test_string], "This is not a master card " + test_string
+        assert cregex.master_cards(test_string) != [test_string], (
+            "This is not a master card " + test_string
+        )
+
 
 def test_cregex_btc_address():
-    test_data = ["1LgqButDNV2rVHe9DATt6WqD8tKZEKvaK2",
-		"19P6EYhu6kZzRy9Au4wRRZVE8RemrxPbZP",
-		"1bones8KbQge9euDn523z5wVhwkTP3uc1",
-		"1Bow5EMqtDGV5n5xZVgdpRPJiiDK6XSjiC"]
+    test_data = [
+        "1LgqButDNV2rVHe9DATt6WqD8tKZEKvaK2",
+        "19P6EYhu6kZzRy9Au4wRRZVE8RemrxPbZP",
+        "1bones8KbQge9euDn523z5wVhwkTP3uc1",
+        "1Bow5EMqtDGV5n5xZVgdpRPJiiDK6XSjiC",
+    ]
 
-    failing_tests = ["2LgqButDNV2rVHe9DATt6WqD8tKZEKvaK2",
-		"19Ry9Au4wRRZVE8RemrxPbZP",
-		"1bones8KbQge9euDn523z5wVhwkTP3uc12939",
-		"1Bow5EMqtDGV5n5xZVgdpR"]
+    failing_tests = [
+        "2LgqButDNV2rVHe9DATt6WqD8tKZEKvaK2",
+        "19Ry9Au4wRRZVE8RemrxPbZP",
+        "1bones8KbQge9euDn523z5wVhwkTP3uc12939",
+        "1Bow5EMqtDGV5n5xZVgdpR",
+    ]
 
     for test_string in test_data:
-        assert cregex.btc_address(test_string) == [test_string], "BTC address regex failed on: " + test_string
+        assert cregex.btc_address(test_string) == [test_string], (
+            "BTC address regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.btc_address(test_string) != [test_string], "This is not a BTC address " + test_string
+        assert cregex.btc_address(test_string) != [test_string], (
+            "This is not a BTC address " + test_string
+        )
+
 
 def test_cregex_street_addresses():
-    test_data = ["101 main st.",
-		"504 parkwood drive",
-		"3 elm boulevard",
-		"500 elm street "]
+    test_data = [
+        "101 main st.",
+        "504 parkwood drive",
+        "3 elm boulevard",
+        "500 elm street ",
+    ]
 
     failing_tests = ["101 main straight"]
 
     for test_string in test_data:
-        assert cregex.street_addresses(test_string) == [test_string], "Street addresses regex failed on: " + test_string
+        assert cregex.street_addresses(test_string) == [test_string], (
+            "Street addresses regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.street_addresses(test_string) != [test_string], "This is not a street address " + test_string
+        assert cregex.street_addresses(test_string) != [test_string], (
+            "This is not a street address " + test_string
+        )
+
 
 def test_cregex_zip_codes():
-    test_data = ["02540",
-		"02540-4119"]
+    test_data = ["02540", "02540-4119"]
 
-    failing_tests = ["10001-1234-5678-9012-3456-7890-1234",
+    failing_tests = [
+        "10001-1234-5678-9012-3456-7890-1234",
         "101 main straight",
-		"123456"]
+        "123456",
+    ]
 
     for test_string in test_data:
-        assert cregex.zip_codes(test_string) == [test_string], "Zip codes regex failed on: " + test_string
+        assert cregex.zip_codes(test_string) == [test_string], (
+            "Zip codes regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.zip_codes(test_string) != [test_string], "This is not a zip code " + test_string
+        assert cregex.zip_codes(test_string) != [test_string], (
+            "This is not a zip code " + test_string
+        )
+
 
 def test_cregex_po_boxes():
-    test_data = ["PO Box 123456",
-		"p.o. box 234234"]
+    test_data = ["PO Box 123456", "p.o. box 234234"]
 
     failing_tests = ["PO Box 1234-5678-9012-3456-7890-1234"]
 
     for test_string in test_data:
-        assert cregex.po_boxes(test_string) == [test_string], "PO boxes regex failed on: " + test_string
+        assert cregex.po_boxes(test_string) == [test_string], (
+            "PO boxes regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.po_boxes(test_string) != [test_string], "This is not a PO box " + test_string
+        assert cregex.po_boxes(test_string) != [test_string], (
+            "This is not a PO box " + test_string
+        )
+
 
 def test_cregex_ssns():
-    test_data = ["000-00-0000",
-		"111-11-1111",
-		"222-22-2222",
-		"123-45-6789"]
+    test_data = ["000-00-0000", "111-11-1111", "222-22-2222", "123-45-6789"]
 
-    failing_tests = ["123-45-6789-1234",
+    failing_tests = [
+        "123-45-6789-1234",
         "1234567891234",
         "123-45-6789-1234",
-        "1234567891234"]
+        "1234567891234",
+    ]
 
     for test_string in test_data:
-        assert cregex.ssn_numbers(test_string) == [test_string], "SSNs regex failed on: " + test_string
+        assert cregex.ssn_numbers(test_string) == [test_string], (
+            "SSNs regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.ssn_numbers(test_string) != [test_string], "This is not an SSN " + test_string
+        assert cregex.ssn_numbers(test_string) != [test_string], (
+            "This is not an SSN " + test_string
+        )
+
 
 def test_cregex_md5_hashes():
-    test_data = ["b5ab01fad5a008d436f76aafc896f9c6",
-		"00000000000000000000000000000000",
-		"fffFFFfFFfFFFfFFFFfFfFfffffFfFFF"]
+    test_data = [
+        "b5ab01fad5a008d436f76aafc896f9c6",
+        "00000000000000000000000000000000",
+        "fffFFFfFFfFFFfFFFFfFfFfffffFfFFF",
+    ]
 
-    failing_tests = ["0cc175b9c0f1b6a831c399e2697723-1234",
+    failing_tests = [
+        "0cc175b9c0f1b6a831c399e2697723-1234",
         "d41d8cd98f00b204e9800998ecf8427e-1234",
         "900150983cd24fb0d6963f7d28e17f72-1234",
         "f96b697d7cb9dd08c81209bcf0aaf94f-1234",
         "b5ab01fad5a008d436f76aafc896f9c600000000",
-		"",
-		"7TS5x1trQs652k4AZ3hJE83YCvJRy0U8",
-		"b5ab01fad5a008-436f76aafc896f9c6"]
+        "",
+        "7TS5x1trQs652k4AZ3hJE83YCvJRy0U8",
+        "b5ab01fad5a008-436f76aafc896f9c6",
+    ]
 
     for test_string in test_data:
-        assert cregex.md5_hashes(test_string) == [test_string], "MD5 hashes regex failed on: " + test_string
+        assert cregex.md5_hashes(test_string) == [test_string], (
+            "MD5 hashes regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.md5_hashes(test_string) != [test_string], "This is not an MD5 hash " + test_string
+        assert cregex.md5_hashes(test_string) != [test_string], (
+            "This is not an MD5 hash " + test_string
+        )
+
 
 def test_cregex_sha1_hashes():
-    test_data = ["da39a3ee5e6b4b0d3255bfef95601890afd80709",
+    test_data = [
+        "da39a3ee5e6b4b0d3255bfef95601890afd80709",
         "0000000000000000000000000000000000000000",
         "ffffffffffffffffffffffffffffffffffffffff",
         "b5ab01fad5a008d436f76aafc896f9c6abcd1234",
-		"0000000000000000000000000000000000000000",
-		"fffFFFfFFfFFFfFFFFfFfFfffffFfFFFffffFFFF"]
+        "0000000000000000000000000000000000000000",
+        "fffFFFfFFfFFFfFFFFfFfFfffffFfFFFffffFFFF",
+    ]
 
-    failing_tests = ["0cc175b9c0f1b6a831c399e2697723-1234",
+    failing_tests = [
+        "0cc175b9c0f1b6a831c399e2697723-1234",
         "d41d8cd98f00b204e9800998ecf8427e-1234",
         "900150983cd24fb0d6963f7d28e17f72-1234",
         "f96b697d7cb9dd08c81209bcf0aaf94f-1234",
         "b5ab01fad5a008d436f76aafc896f9c600000000202020202020202020202020",
-		"",
-		"7TS5x1trQs652k4AZ3hJE83YCvJRy0U85x1trQs652k4AZ3hJE83YCvJRy0U8asd",
-		"b5ab01fad5a008-436f76aafc896f9c6-436f76aafc896f9c6-436f76aafc896"
-        ]
+        "",
+        "7TS5x1trQs652k4AZ3hJE83YCvJRy0U85x1trQs652k4AZ3hJE83YCvJRy0U8asd",
+        "b5ab01fad5a008-436f76aafc896f9c6-436f76aafc896f9c6-436f76aafc896",
+    ]
 
     for test_string in test_data:
-        assert cregex.sha1_hashes(test_string) == [test_string], "SHA1 hashes regex failed on: " + test_string
+        assert cregex.sha1_hashes(test_string) == [test_string], (
+            "SHA1 hashes regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.sha1_hashes(test_string) != [test_string], "This is not an SHA1 hash " + test_string
+        assert cregex.sha1_hashes(test_string) != [test_string], (
+            "This is not an SHA1 hash " + test_string
+        )
+
 
 def test_cregex_sha256_hashes():
-    test_data = ["3f4146a1d0b5dac26562ff7dc6248573f4e996cf764a0f517318ff398dcfa792",
-		"0000000000000000000000000000000000000000000000000000000000000000",
-		"fffFFFfFFfFFFfFFFFfFfFfffffFfFFFffffFFFFfffffFFFFFffFFffFFffFFff"]
+    test_data = [
+        "3f4146a1d0b5dac26562ff7dc6248573f4e996cf764a0f517318ff398dcfa792",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "fffFFFfFFfFFFfFFFFfFfFfffffFfFFFffffFFFFfffffFFFFFffFFffFFffFFff",
+    ]
 
-    failing_tests = ["3f4146a1d0b5dac26562ff7dc6248573f4e996cf764a0f517318ff398dcfa7920",
-		"",
-		"e9iLS075z9HAJlUWg2ZpK5hRxjLeSpIqMKJO67c739VYf7Bj7eR1WjOO82IHcXVd",
-		"b5ab01fad5a008-436f76aafc896f9c6-436f76aafc896f9c6-436f76aafc896"
-        ]
+    failing_tests = [
+        "3f4146a1d0b5dac26562ff7dc6248573f4e996cf764a0f517318ff398dcfa7920",
+        "",
+        "e9iLS075z9HAJlUWg2ZpK5hRxjLeSpIqMKJO67c739VYf7Bj7eR1WjOO82IHcXVd",
+        "b5ab01fad5a008-436f76aafc896f9c6-436f76aafc896f9c6-436f76aafc896",
+    ]
 
     for test_string in test_data:
-        assert cregex.sha256_hashes(test_string) == [test_string], "SHA256 hashes regex failed on: " + test_string
+        assert cregex.sha256_hashes(test_string) == [test_string], (
+            "SHA256 hashes regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.sha256_hashes(test_string) != [test_string], "This is not an SHA256 hash " + test_string
+        assert cregex.sha256_hashes(test_string) != [test_string], (
+            "This is not an SHA256 hash " + test_string
+        )
+
 
 def test_cregex_isbn13s():
-    test_data = ["978-3-16-148410-0",
-		"978-1-56619-909-4",
-		"133-1-12144-909-9"]
+    test_data = ["978-3-16-148410-0", "978-1-56619-909-4", "133-1-12144-909-9"]
 
-    failing_tests = ["1-56619-909-3",
-		"1-33342-100-1",
-		"2-33342-362-9"]
+    failing_tests = ["1-56619-909-3", "1-33342-100-1", "2-33342-362-9"]
 
     for test_string in test_data:
-        assert cregex.isbn13s(test_string) == [test_string], "ISBN13s regex failed on: " + test_string
+        assert cregex.isbn13s(test_string) == [test_string], (
+            "ISBN13s regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.isbn13s(test_string) != [test_string], "This is not an ISBN13 " + test_string
+        assert cregex.isbn13s(test_string) != [test_string], (
+            "This is not an ISBN13 " + test_string
+        )
+
 
 def test_cregex_isbn10s():
-    test_data = ["3-16-148410-0",
-        "1-56619-909-4",
-        "1-33342-100-1"]
+    test_data = ["3-16-148410-0", "1-56619-909-4", "1-33342-100-1"]
 
-    failing_tests = ["978-3-16-148410-0",
-		"978-1-56619-909-4",
-		"133-1-12144-909-9"]
+    failing_tests = ["978-3-16-148410-0", "978-1-56619-909-4", "133-1-12144-909-9"]
 
     for test_string in test_data:
-        assert cregex.isbn10s(test_string) == [test_string], "ISBN10s regex failed on: " + test_string
+        assert cregex.isbn10s(test_string) == [test_string], (
+            "ISBN10s regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.isbn10s(test_string) != [test_string], "This is not an ISBN10 " + test_string
+        assert cregex.isbn10s(test_string) != [test_string], (
+            "This is not an ISBN10 " + test_string
+        )
+
 
 def test_cregex_mac_addresses():
-    test_data = ["f8:2f:a4:fe:76:d2",
-		"F8:2F:A4:FE:76:D2",
-		"3D-F2-C9-A6-B3-4F"]
+    test_data = ["f8:2f:a4:fe:76:d2", "F8:2F:A4:FE:76:D2", "3D-F2-C9-A6-B3-4F"]
 
-    failing_tests = ["3D:F2:C9:A6:B3:4G",
-		"f0:2f:P4:Be:96:J5"]
+    failing_tests = ["3D:F2:C9:A6:B3:4G", "f0:2f:P4:Be:96:J5"]
 
     for test_string in test_data:
-        assert cregex.mac_addresses(test_string) == [test_string], "MAC addresses regex failed on: " + test_string
+        assert cregex.mac_addresses(test_string) == [test_string], (
+            "MAC addresses regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.mac_addresses(test_string) != [test_string], "This is not an MAC address " + test_string
+        assert cregex.mac_addresses(test_string) != [test_string], (
+            "This is not an MAC address " + test_string
+        )
+
 
 def test_cregex_git_repos():
-    test_data = ["https://github.com/brootware/commonregex-improved.git",
-		"git@github.com:brootware/commonregex-improved.git"]
+    test_data = [
+        "https://github.com/brootware/commonregex-improved.git",
+        "git@github.com:brootware/commonregex-improved.git",
+    ]
 
-    failing_tests = ["https://github.com/brootware/commonregex-improved",
-		"test@github.com:brootware/commonregex-improved.git"]
+    failing_tests = [
+        "https://github.com/brootware/commonregex-improved",
+        "test@github.com:brootware/commonregex-improved.git",
+    ]
 
     for test_string in test_data:
-        assert cregex.git_repos(test_string) == [test_string], "Git repos regex failed on: " + test_string
+        assert cregex.git_repos(test_string) == [test_string], (
+            "Git repos regex failed on: " + test_string
+        )
 
     for test_string in failing_tests:
-        assert cregex.git_repos(test_string) != [test_string], "This is not a Git repo " + test_string
+        assert cregex.git_repos(test_string) != [test_string], (
+            "This is not a Git repo " + test_string
+        )


### PR DESCRIPTION
There are very long lines in the code, so I set the max-line-lengh to 88 for flake8 and split the long regex strings.

l also added an "r" to the regex strings to avoid the DeprecationWarning: invalid escape sequence warning appearing when test_crim.py runs.